### PR TITLE
Reorganisation mapping

### DIFF
--- a/vortex_radioss/animtod3plot/Anim_to_D3plot.py
+++ b/vortex_radioss/animtod3plot/Anim_to_D3plot.py
@@ -111,10 +111,10 @@ class convert:
         result = np.stack([
             S_global[:, 0, 0],  # ox
             S_global[:, 1, 1],  # oy
-            np.zeros(n),        # oz = 0 (out-of-plane)
+            S_global[:, 2, 2],   # oz 
             S_global[:, 0, 1],  # oxy
-            np.zeros(n),         # oyz = 0 (out-of-plane)
-            np.zeros(n)          # oxz = 0 (out-of-plane)
+            S_global[:, 1, 2],   # oyz
+            S_global[:, 0, 2],   # oxz 
         ], axis=-1)
 
         return result
@@ -136,8 +136,7 @@ class convert:
         # Mid surface stresses if present are not converted
         # Only Upper and Lower stresses are converted
         # out of plane stresses arre not converted
-
-         
+        
         shell_num = len(data[0])
         nip, rotation_matrices = data[2]
 


### PR DESCRIPTION
# Improvement of data mapping according to LS-DYNA documentation

## Context  
Initially, information was grouped under generic flags such as "SHELL" or "Node". However, the LS-DYNA documentation recommends organizing data by types of information (stress, strain, energy, etc.), where each flag contains data related to all element types (shells, solids, etc.).

## Objective  
Align the data mapping structure with the one defined in the LS-DYNA documentation to better organize information according to its functional nature.

## Changes made  
- Reorganization of data for grouping by functional categories (STRFLG, ENGFLG, etc.).
- inversion of the Upper/Lower order in the stress tensor

## Addition of a mapping management function  
A new function `insert_into_extent_binary` has been added to simplify and structure the management of data within the nested dictionary `database_extent_binary`.

This function allows using **strings** as sub-keys in the dictionary instead of numbers, improving the readability and clarity of the mapping.

## Related processing adjustments  
Since sub-keys are now strings instead of numeric indices, the code tracking valid data groups was adapted.

Previously, a maximum group index was stored per flag; now, a **set** of valid groups is maintained.

The code first collects valid groups based on dependency checks, then generates output arrays or zero arrays accordingly.

This update try to aligns the processing with the new mapping structure while preserving existing functionality.
