### PR TITLE
Import numpy.core.defchararray

### DIFF
--- a/vortex_radioss/animtod3plot/Anim_to_D3plot.py
+++ b/vortex_radioss/animtod3plot/Anim_to_D3plot.py
@@ -8,6 +8,7 @@ from lasso.dyna.array_type import ArrayType
 from vortex_radioss.animtod3plot.RadiossReader import RadiossReader
 
 import numpy as np
+from numpy.core import defchararray
 import os
 import time
 from tqdm import tqdm


### PR DESCRIPTION
When trying to convert Radioss data to .d3plot, neither 'OpenRadioss_gui.py' nor 'Anim_to_D3plot.py' import numpy.core.defchararray (not just np), which lead to the an error messagebox 'Error in d3plot conversion' in 'job_window.py'.

Just a small modification while exploring. Thanks to authors for opening valuable Radioss to public altruisticly.